### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-gulp.yml
+++ b/.github/workflows/npm-gulp.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master", "rework" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/141512114/pixle/security/code-scanning/1](https://github.com/141512114/pixle/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/npm-gulp.yml` at the workflow root (between `on:` and `jobs:`), so it applies to all jobs unless overridden.  
For this workflow, the minimal safe setting is:

- `contents: read`

This preserves current behavior (checkout and build/test steps) while removing implicit reliance on repository/org token defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
